### PR TITLE
fix(icon): add part attribute for CSS overrides

### DIFF
--- a/src/components/icon/icon.ts
+++ b/src/components/icon/icon.ts
@@ -28,6 +28,9 @@ export class Icon extends LitElement {
     const attributes = JSON.parse(JSON.stringify(this.icon.attrs));
     attributes.fill = this.fill;
 
+    // Add ::part attribute to allow CSS overrides from parent component (responsive size, etc.)
+    attributes.part = 'kd-icon-part';
+
     if (this.sizeOverride) {
       attributes.width = this.sizeOverride;
       attributes.height = this.sizeOverride;


### PR DESCRIPTION
Add part attribute to SVG element so parent components can override styles using the ::part(kd-icon-part) pseudo-element selector.

This can be used to resize the icon per breakpoint from the CSS of a parent component.