### PR TITLE
feat(visibility-utils): add responsive utility classes for visibility

### DIFF
--- a/src/scss/mixins/index.scss
+++ b/src/scss/mixins/index.scss
@@ -2,3 +2,4 @@
 @use 'grid.scss';
 @use 'layout.scss';
 @use 'spacing.scss';
+@use 'visibility.scss';

--- a/src/scss/mixins/visibility.scss
+++ b/src/scss/mixins/visibility.scss
@@ -1,0 +1,16 @@
+@mixin sr-only {
+	border: 0;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	text-indent: 200%;
+	white-space: nowrap;
+	width: 1px;
+}
+
+@mixin hidden {
+	display: none !important;
+}

--- a/src/scss/mixins/visibility.scss
+++ b/src/scss/mixins/visibility.scss
@@ -1,3 +1,5 @@
+@use '../variables/breakpoints.scss';
+
 @mixin sr-only {
   border: 0;
   clip: rect(0, 0, 0, 0);
@@ -13,4 +15,34 @@
 
 @mixin hidden {
   display: none !important;
+}
+
+@mixin hidden-sm {
+  @media (max-width: calc(#{breakpoints.$bp-md} - 1px)) {
+    display: none !important;
+  }
+}
+
+@mixin hidden-md {
+  @media (min-width: breakpoints.$bp-md) and (max-width: calc(#{breakpoints.$bp-lg} - 1px)) {
+    display: none !important;
+  }
+}
+
+@mixin hidden-lg {
+  @media (min-width: breakpoints.$bp-lg) and (max-width: calc(#{breakpoints.$bp-xl} - 1px)) {
+    display: none !important;
+  }
+}
+
+@mixin hidden-xl {
+  @media (min-width: breakpoints.$bp-xl) and (max-width: calc(#{breakpoints.$bp-max} - 1px)) {
+    display: none !important;
+  }
+}
+
+@mixin hidden-max {
+  @media (min-width: breakpoints.$bp-max) {
+    display: none !important;
+  }
 }

--- a/src/scss/mixins/visibility.scss
+++ b/src/scss/mixins/visibility.scss
@@ -1,16 +1,16 @@
 @mixin sr-only {
-	border: 0;
-	clip: rect(0, 0, 0, 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	text-indent: 200%;
-	white-space: nowrap;
-	width: 1px;
+  border: 0;
+  clip: rect(0, 0, 0, 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  text-indent: 200%;
+  white-space: nowrap;
+  width: 1px;
 }
 
 @mixin hidden {
-	display: none !important;
+  display: none !important;
 }

--- a/src/scss/utility/index.scss
+++ b/src/scss/utility/index.scss
@@ -2,3 +2,4 @@
 @use 'grid.scss';
 @use 'layout.scss';
 @use 'spacing.scss';
+@use 'visibility.scss';

--- a/src/scss/utility/visibility.scss
+++ b/src/scss/utility/visibility.scss
@@ -2,39 +2,39 @@
 @use '../variables/breakpoints.scss';
 
 .kd-visibility--sr-only {
-	@include visibility.sr-only;
+  @include visibility.sr-only;
 }
 
 .kd-visibility--hidden {
-	@include visibility.hidden;
+  @include visibility.hidden;
 }
 
 @media (max-width: calc(#{breakpoints.$bp-md} - 1px)) {
-	.kd-visibility--hidden-sm {
-		@include visibility.hidden;
-	}
+  .kd-visibility--hidden-sm {
+    @include visibility.hidden;
+  }
 }
 
 @media (min-width: breakpoints.$bp-md) and (max-width: calc(#{breakpoints.$bp-lg} - 1px)) {
-	.kd-visibility--hidden-md {
-		@include visibility.hidden;
-	}
+  .kd-visibility--hidden-md {
+    @include visibility.hidden;
+  }
 }
 
 @media (min-width: breakpoints.$bp-lg) and (max-width: calc(#{breakpoints.$bp-xl} - 1px)) {
-	.kd-visibility--hidden-lg {
-		@include visibility.hidden;
-	}
+  .kd-visibility--hidden-lg {
+    @include visibility.hidden;
+  }
 }
 
 @media (min-width: breakpoints.$bp-xl) and (max-width: calc(#{breakpoints.$bp-max} - 1px)) {
-	.kd-visibility--hidden-xl {
-		@include visibility.hidden;
-	}
+  .kd-visibility--hidden-xl {
+    @include visibility.hidden;
+  }
 }
 
 @media (min-width: breakpoints.$bp-max) {
-	.kd-visibility--hidden-max {
-		@include visibility.hidden;
-	}
+  .kd-visibility--hidden-max {
+    @include visibility.hidden;
+  }
 }

--- a/src/scss/utility/visibility.scss
+++ b/src/scss/utility/visibility.scss
@@ -1,0 +1,40 @@
+@use '../mixins/visibility.scss';
+@use '../variables/breakpoints.scss';
+
+.kd-visibility--sr-only {
+	@include visibility.sr-only;
+}
+
+.kd-visibility--hidden {
+	@include visibility.hidden;
+}
+
+@media (max-width: calc(#{breakpoints.$bp-md} - 1px)) {
+	.kd-visibility--hidden-sm {
+		@include visibility.hidden;
+	}
+}
+
+@media (min-width: breakpoints.$bp-md) and (max-width: calc(#{breakpoints.$bp-lg} - 1px)) {
+	.kd-visibility--hidden-md {
+		@include visibility.hidden;
+	}
+}
+
+@media (min-width: breakpoints.$bp-lg) and (max-width: calc(#{breakpoints.$bp-xl} - 1px)) {
+	.kd-visibility--hidden-lg {
+		@include visibility.hidden;
+	}
+}
+
+@media (min-width: breakpoints.$bp-xl) and (max-width: calc(#{breakpoints.$bp-max} - 1px)) {
+	.kd-visibility--hidden-xl {
+		@include visibility.hidden;
+	}
+}
+
+@media (min-width: breakpoints.$bp-max) {
+	.kd-visibility--hidden-max {
+		@include visibility.hidden;
+	}
+}

--- a/src/scss/utility/visibility.scss
+++ b/src/scss/utility/visibility.scss
@@ -9,32 +9,22 @@
   @include visibility.hidden;
 }
 
-@media (max-width: calc(#{breakpoints.$bp-md} - 1px)) {
-  .kd-visibility--hidden-sm {
-    @include visibility.hidden;
-  }
+.kd-visibility--hidden-sm {
+  @include visibility.hidden-sm;
 }
 
-@media (min-width: breakpoints.$bp-md) and (max-width: calc(#{breakpoints.$bp-lg} - 1px)) {
-  .kd-visibility--hidden-md {
-    @include visibility.hidden;
-  }
+.kd-visibility--hidden-md {
+  @include visibility.hidden-md;
 }
 
-@media (min-width: breakpoints.$bp-lg) and (max-width: calc(#{breakpoints.$bp-xl} - 1px)) {
-  .kd-visibility--hidden-lg {
-    @include visibility.hidden;
-  }
+.kd-visibility--hidden-lg {
+  @include visibility.hidden-lg;
 }
 
-@media (min-width: breakpoints.$bp-xl) and (max-width: calc(#{breakpoints.$bp-max} - 1px)) {
-  .kd-visibility--hidden-xl {
-    @include visibility.hidden;
-  }
+.kd-visibility--hidden-xl {
+  @include visibility.hidden-xl;
 }
 
-@media (min-width: breakpoints.$bp-max) {
-  .kd-visibility--hidden-max {
-    @include visibility.hidden;
-  }
+.kd-visibility--hidden-max {
+  @include visibility.hidden-max;
 }

--- a/src/stories/Visibility.mdx
+++ b/src/stories/Visibility.mdx
@@ -1,0 +1,60 @@
+import { Meta, Story, Canvas, Controls, Stories } from '@storybook/blocks';
+import * as VisibilityStories from './Visibility.stories.js';
+
+<Meta of={VisibilityStories} />
+
+## Example
+
+<Canvas>
+  <Story of={VisibilityStories.Visibility} />
+</Canvas>
+
+## Usage
+
+### SCSS Mixins
+
+```css
+@use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/visibility.scss';
+
+.your-css-selector {
+  @include visibility.sr-only;
+  @include visibility.hidden;
+  @include visibility.hidden-sm;
+  @include visibility.hidden-md;
+  @include visibility.hidden-lg;
+  @include visibility.hidden-xl;
+  @include visibility.hidden-max;
+}
+```
+
+### Utility Classes
+
+#### Import to SCSS
+
+```css
+@use '~@kyndryl-design-system/shidoka-foundation/scss/utility/visibility.scss';
+```
+
+#### Import to CSS
+
+```css
+@import '@kyndryl-design-system/shidoka-foundation/css/visibility.css';
+```
+
+#### Import to JS
+
+```js
+import '@kyndryl-design-system/shidoka-foundation/css/visibility.css';
+```
+
+#### Example HTML
+
+```html
+<div class="kd-visibility--sr-only">Screen reader only</div>
+<div class="kd-visibility--hidden">Hidden all breakpoints</div>
+<div class="kd-visibility--hidden-sm">Hidden Small (sm)</div>
+<div class="kd-visibility--hidden-md">Hidden Medium (md)</div>
+<div class="kd-visibility--hidden-lg">Hidden Large (lg)</div>
+<div class="kd-visibility--hidden-xl">Hidden X-Large (xl)</div>
+<div class="kd-visibility--hidden-max">Hidden Max (max)</div>
+```

--- a/src/stories/Visibility.stories.js
+++ b/src/stories/Visibility.stories.js
@@ -1,0 +1,61 @@
+import { html } from 'lit';
+import { classMap } from 'lit/directives/class-map.js';
+
+export default {
+  title: 'Foundation/Visibility',
+  decorators: [
+    (story) =>
+      html`
+        <style>
+          .storybook-visibility-example {
+            align-items: center;
+            background: var(--kd-color-cloud-10);
+            display: flex;
+            margin: 16px;
+            min-height: 4em;
+            padding: 16px;
+          }
+        </style>
+        ${story()}
+      `,
+  ],
+};
+
+const args = {};
+
+export const Visibility = {
+  args: args,
+  render: (args) => {
+    return html`
+      <div class="storybook-visibility-example">
+        This block includes text for screen readers only.
+        <div class="kd-visibility--sr-only">screen reader only content</div>
+      </div>
+      <div class="storybook-visibility-example">
+        <div class="kd-visibility--hidden-sm">
+          Text hidden at Small (sm) breakpoint.
+        </div>
+      </div>
+      <div class="storybook-visibility-example">
+        <div class="kd-visibility--hidden-md">
+          Text hidden at Medium (md) breakpoint.
+        </div>
+      </div>
+      <div class="storybook-visibility-example">
+        <div class="kd-visibility--hidden-lg">
+          Text hidden at Large (lg) breakpoint.
+        </div>
+      </div>
+      <div class="storybook-visibility-example">
+        <div class="kd-visibility--hidden-xl">
+          Text hidden at X-Large (xl) breakpoint.
+        </div>
+      </div>
+      <div class="storybook-visibility-example">
+        <div class="kd-visibility--hidden-max">
+          Text hidden at Max (max) breakpoint.
+        </div>
+      </div>
+    `;
+  },
+};


### PR DESCRIPTION
Add responsive utility classes and mixins for controlling visibility of elements.

This provides a standard way of showing/hiding content across breakpoints without needing to adding custom styles per component. It also adds a screen reader only style for accessibility.