### PR TITLE
feat (Expandable-Tile): Added expandable tile, lit lifecycle and sampl…

### DIFF
--- a/custom-elements.json
+++ b/custom-elements.json
@@ -102,134 +102,29 @@
             "name": "SplitButtonOption",
             "module": "./components/splitButton"
           }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/common/defs/breakpoints.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "BREAKPOINTS",
-          "type": {
-            "text": "object"
-          },
-          "default": "{\r\n  SM: 'sm',\r\n  MD: 'md',\r\n  LG: 'lg',\r\n  XL: 'xl',\r\n  MAX: 'max',\r\n}",
-          "description": "Breakpoint values defined in variable: --kd-current-breakpoint\r\nUsed for conditional logic and/or rendering in component JS\r\nby matching the current breakpoint to one of these values."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "BREAKPOINTS",
-          "declaration": {
-            "name": "BREAKPOINTS",
-            "module": "src/common/defs/breakpoints.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/common/helpers/breakpoints.ts",
-      "declarations": [
-        {
-          "kind": "function",
-          "name": "getCurrentBreakpoint",
-          "description": "Get the current breakpoint from CSS variable.\r\nUsed for conditional logic and/or rendering in component JS\r\nby matching the current breakpoint with values defined in common/defs/breakpoints."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "getCurrentBreakpoint",
-          "declaration": {
-            "name": "getCurrentBreakpoint",
-            "module": "src/common/helpers/breakpoints.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/common/helpers/events.ts",
-      "declarations": [
-        {
-          "kind": "function",
-          "name": "debounce",
-          "parameters": [
-            {
-              "name": "fn",
-              "type": {
-                "text": "Function"
-              }
-            },
-            {
-              "name": "ms",
-              "default": "100"
-            }
-          ]
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "debounce",
-          "declaration": {
-            "name": "debounce",
-            "module": "src/common/helpers/events.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/common/helpers/storybook.ts",
-      "declarations": [
-        {
-          "kind": "function",
-          "name": "stringToReactHtml",
-          "parameters": [
-            {
-              "name": "string",
-              "type": {
-                "text": "String"
-              }
-            }
-          ]
         },
         {
-          "kind": "function",
-          "name": "createOptionsArray",
-          "parameters": [
-            {
-              "name": "options",
-              "default": "{}",
-              "type": {
-                "text": "*"
-              },
-              "description": " imported enums object"
-            }
-          ],
-          "description": "Convert an object to an array of only its values.\r\nUsed when importing enums in component stories for populating argType dropdowns."
-        }
-      ],
-      "exports": [
-        {
           "kind": "js",
-          "name": "stringToReactHtml",
+          "name": "Sample",
           "declaration": {
-            "name": "stringToReactHtml",
-            "module": "src/common/helpers/storybook.ts"
+            "name": "Sample",
+            "module": "./components/sample"
           }
         },
         {
           "kind": "js",
-          "name": "createOptionsArray",
+          "name": "LitLifecycle",
           "declaration": {
-            "name": "createOptionsArray",
-            "module": "src/common/helpers/storybook.ts"
+            "name": "LitLifecycle",
+            "module": "./components/lifecycle"
+          }
+        },
+        {
+          "kind": "js",
+          "name": "ExpandableTile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "./components/expandableTile"
           }
         }
       ]
@@ -1164,6 +1059,132 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/expandableTile/expandableTile.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Expandable Tile component",
+          "name": "ExpandableTile",
+          "slots": [
+            {
+              "description": "The string that displays as title on Tile",
+              "name": "title"
+            },
+            {
+              "description": "The string that displays on the toggle",
+              "name": "unnamed"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "expanded",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "expanded state",
+              "attribute": "expanded",
+              "reflects": true
+            },
+            {
+              "kind": "method",
+              "name": "_handleClick",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_handleKeypress",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_toggleExpanded",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_emitToggleEvent",
+              "privacy": "private"
+            }
+          ],
+          "events": [
+            {
+              "description": "Emits the `expanded` state when tile component open and closes.",
+              "name": "on-toggle"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "expanded",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "expanded state",
+              "fieldName": "expanded"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-expandable-tile",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ExpandableTile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "src/components/expandableTile/expandableTile.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-expandable-tile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "src/components/expandableTile/expandableTile.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/expandableTile/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ExpandableTile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "./expandableTile"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/icon/icon.ts",
       "declarations": [
         {
@@ -1273,6 +1294,494 @@
           "declaration": {
             "name": "Icon",
             "module": "./icon"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/lifecycle/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LitLifecycle",
+          "declaration": {
+            "name": "LitLifecycle",
+            "module": "./lifecycle"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/lifecycle/lifecycle.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "LitLifecycle component",
+          "name": "LitLifecycle",
+          "members": [
+            {
+              "kind": "field",
+              "name": "counter",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "Counter initial state",
+              "attribute": "counter"
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "BUTTON_SIZES"
+              },
+              "description": "Button size small, medium, large default small",
+              "attribute": "size"
+            },
+            {
+              "kind": "field",
+              "name": "primaryBtnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "primaryBtnText.",
+              "attribute": "primaryBtnText"
+            },
+            {
+              "kind": "field",
+              "name": "secondaryBtnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "secondaryBtnText.",
+              "attribute": "secondaryBtnText"
+            },
+            {
+              "kind": "method",
+              "name": "incrementCounter"
+            },
+            {
+              "kind": "method",
+              "name": "decrementCounter"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "counter",
+              "type": {
+                "text": "number"
+              },
+              "default": "0",
+              "description": "Counter initial state",
+              "fieldName": "counter"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "BUTTON_SIZES"
+              },
+              "description": "Button size small, medium, large default small",
+              "fieldName": "size"
+            },
+            {
+              "name": "primaryBtnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "primaryBtnText.",
+              "fieldName": "primaryBtnText"
+            },
+            {
+              "name": "secondaryBtnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "secondaryBtnText.",
+              "fieldName": "secondaryBtnText"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-lifecycle",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "LitLifecycle",
+          "declaration": {
+            "name": "LitLifecycle",
+            "module": "src/components/lifecycle/lifecycle.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-lifecycle",
+          "declaration": {
+            "name": "LitLifecycle",
+            "module": "src/components/lifecycle/lifecycle.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/link/defs.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/link/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Link",
+          "declaration": {
+            "name": "Link",
+            "module": "./link"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/link/link.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Component for navigation links.",
+          "name": "Link",
+          "slots": [
+            {
+              "description": "Slot for link text.",
+              "name": "unnamed"
+            },
+            {
+              "description": "Slot for an icon.",
+              "name": "icon"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Link url.",
+              "attribute": "href"
+            },
+            {
+              "kind": "field",
+              "name": "target",
+              "type": {
+                "text": "LINK_TARGETS"
+              },
+              "description": "Defines a target attribute for where to load the URL. Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
+              "attribute": "target"
+            },
+            {
+              "kind": "field",
+              "name": "kind",
+              "type": {
+                "text": "LINK_TYPES"
+              },
+              "description": "The Link type. Primary(App) or Secondary(Web).",
+              "attribute": "kind"
+            },
+            {
+              "kind": "field",
+              "name": "rel",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Defines a relationship between a linked resource and the document. An empty string (default) means no particular relationship",
+              "attribute": "rel"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the link is disabled.",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "standalone",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether you want the standalone Link. By default false. Use this prop. (true) with icon with link variant.",
+              "attribute": "standalone"
+            },
+            {
+              "kind": "field",
+              "name": "iconLeft",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Positions icon on the left.",
+              "attribute": "iconLeft"
+            },
+            {
+              "kind": "method",
+              "name": "returnClassMap",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "handleClick",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            }
+          ],
+          "events": [
+            {
+              "description": "Captures the click event and emits the original event details.",
+              "name": "on-click"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Link url.",
+              "fieldName": "href"
+            },
+            {
+              "name": "target",
+              "type": {
+                "text": "LINK_TARGETS"
+              },
+              "description": "Defines a target attribute for where to load the URL. Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
+              "fieldName": "target"
+            },
+            {
+              "name": "kind",
+              "type": {
+                "text": "LINK_TYPES"
+              },
+              "description": "The Link type. Primary(App) or Secondary(Web).",
+              "fieldName": "kind"
+            },
+            {
+              "name": "rel",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Defines a relationship between a linked resource and the document. An empty string (default) means no particular relationship",
+              "fieldName": "rel"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the link is disabled.",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "standalone",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Whether you want the standalone Link. By default false. Use this prop. (true) with icon with link variant.",
+              "fieldName": "standalone"
+            },
+            {
+              "name": "iconLeft",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Positions icon on the left.",
+              "fieldName": "iconLeft"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-link",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Link",
+          "declaration": {
+            "name": "Link",
+            "module": "src/components/link/link.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-link",
+          "declaration": {
+            "name": "Link",
+            "module": "src/components/link/link.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/sample/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Sample",
+          "declaration": {
+            "name": "Sample",
+            "module": "./sample"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/sample/sample.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Sample component",
+          "name": "Sample",
+          "members": [
+            {
+              "kind": "field",
+              "name": "message",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Hi there!'",
+              "description": "message.",
+              "attribute": "message"
+            },
+            {
+              "kind": "field",
+              "name": "submessage",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Hi there!'",
+              "description": "submessage.",
+              "attribute": "submessage"
+            },
+            {
+              "kind": "field",
+              "name": "option",
+              "type": {
+                "text": "LINK_TARGETS"
+              },
+              "description": "Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
+              "attribute": "option"
+            },
+            {
+              "kind": "method",
+              "name": "handleClick",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            }
+          ],
+          "events": [
+            {
+              "description": "Captures the click event and emits the original event details.",
+              "name": "on-click"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "message",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Hi there!'",
+              "description": "message.",
+              "fieldName": "message"
+            },
+            {
+              "name": "submessage",
+              "type": {
+                "text": "string"
+              },
+              "default": "'Hi there!'",
+              "description": "submessage.",
+              "fieldName": "submessage"
+            },
+            {
+              "name": "option",
+              "type": {
+                "text": "LINK_TARGETS"
+              },
+              "description": "Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
+              "fieldName": "option"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-sample",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Sample",
+          "declaration": {
+            "name": "Sample",
+            "module": "src/components/sample/sample.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-sample",
+          "declaration": {
+            "name": "Sample",
+            "module": "src/components/sample/sample.ts"
           }
         }
       ]
@@ -1841,470 +2350,129 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/link/defs.ts",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/link/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "Link",
-          "declaration": {
-            "name": "Link",
-            "module": "./link"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/link/link.ts",
+      "path": "src/common/defs/breakpoints.ts",
       "declarations": [
         {
-          "kind": "class",
-          "description": "Component for navigation links.",
-          "name": "Link",
-          "slots": [
-            {
-              "description": "Slot for link text.",
-              "name": "unnamed"
-            },
-            {
-              "description": "Slot for an icon.",
-              "name": "icon"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "href",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Link url.",
-              "attribute": "href"
-            },
-            {
-              "kind": "field",
-              "name": "target",
-              "type": {
-                "text": "LINK_TARGETS"
-              },
-              "description": "Defines a target attribute for where to load the URL. Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
-              "attribute": "target"
-            },
-            {
-              "kind": "field",
-              "name": "kind",
-              "type": {
-                "text": "LINK_TYPES"
-              },
-              "description": "The Link type. Primary(App) or Secondary(Web).",
-              "attribute": "kind"
-            },
-            {
-              "kind": "field",
-              "name": "rel",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Defines a relationship between a linked resource and the document. An empty string (default) means no particular relationship",
-              "attribute": "rel"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Determines if the link is disabled.",
-              "attribute": "disabled",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "standalone",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether you want the standalone Link. By default false. Use this prop. (true) with icon with link variant.",
-              "attribute": "standalone"
-            },
-            {
-              "kind": "field",
-              "name": "iconLeft",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Positions icon on the left.",
-              "attribute": "iconLeft"
-            },
-            {
-              "kind": "method",
-              "name": "returnClassMap",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "handleClick",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            }
-          ],
-          "events": [
-            {
-              "description": "Captures the click event and emits the original event details.",
-              "name": "on-click"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "href",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Link url.",
-              "fieldName": "href"
-            },
-            {
-              "name": "target",
-              "type": {
-                "text": "LINK_TARGETS"
-              },
-              "description": "Defines a target attribute for where to load the URL. Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
-              "fieldName": "target"
-            },
-            {
-              "name": "kind",
-              "type": {
-                "text": "LINK_TYPES"
-              },
-              "description": "The Link type. Primary(App) or Secondary(Web).",
-              "fieldName": "kind"
-            },
-            {
-              "name": "rel",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Defines a relationship between a linked resource and the document. An empty string (default) means no particular relationship",
-              "fieldName": "rel"
-            },
-            {
-              "name": "disabled",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Determines if the link is disabled.",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "standalone",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Whether you want the standalone Link. By default false. Use this prop. (true) with icon with link variant.",
-              "fieldName": "standalone"
-            },
-            {
-              "name": "iconLeft",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Positions icon on the left.",
-              "fieldName": "iconLeft"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
+          "kind": "variable",
+          "name": "BREAKPOINTS",
+          "type": {
+            "text": "object"
           },
-          "tagName": "kd-link",
-          "customElement": true
+          "default": "{\n  SM: 'sm',\n  MD: 'md',\n  LG: 'lg',\n  XL: 'xl',\n  MAX: 'max',\n}",
+          "description": "Breakpoint values defined in variable: --kd-current-breakpoint\nUsed for conditional logic and/or rendering in component JS\nby matching the current breakpoint to one of these values."
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "Link",
+          "name": "BREAKPOINTS",
           "declaration": {
-            "name": "Link",
-            "module": "src/components/link/link.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kd-link",
-          "declaration": {
-            "name": "Link",
-            "module": "src/components/link/link.ts"
+            "name": "BREAKPOINTS",
+            "module": "src/common/defs/breakpoints.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/sample/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "Sample",
-          "declaration": {
-            "name": "Sample",
-            "module": "./sample"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/sample/sample.ts",
+      "path": "src/common/helpers/breakpoints.ts",
       "declarations": [
         {
-          "kind": "class",
-          "description": "Component for sample message.",
-          "name": "Sample",
-          "events": [
-            {
-              "description": "Captures the click event and emits the original event details.",
-              "name": "on-click"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "message",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "message string",
-              "fieldName": "message"
-            },
-            {
-              "kind": "field",
-              "name": "submessage",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "submessage string",
-              "attribute": "submessage"
-            },
-            {
-              "name": "option",
-              "type": {
-                "text": "LINK_TARGETS"
-              },
-              "description": "Defines a target attribute for where to load the URL. Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
-              "fieldName": "target"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kd-sample",
-          "customElement": true
+          "kind": "function",
+          "name": "getCurrentBreakpoint",
+          "description": "Get the current breakpoint from CSS variable.\nUsed for conditional logic and/or rendering in component JS\nby matching the current breakpoint with values defined in common/defs/breakpoints."
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "Sample",
+          "name": "getCurrentBreakpoint",
           "declaration": {
-            "name": "Sample",
-            "module": "src/components/sample/sample.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kd-sample",
-          "declaration": {
-            "name": "Sample",
-            "module": "src/components/sample/sample.ts"
+            "name": "getCurrentBreakpoint",
+            "module": "src/common/helpers/breakpoints.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/lifecycle/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "Lifecycle",
-          "declaration": {
-            "name": "Lifecycle",
-            "module": "./lifecycle"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/lifecycle/lifecycle.ts",
+      "path": "src/common/helpers/events.ts",
       "declarations": [
         {
-          "kind": "class",
-          "description": "Component for lifecycle events.",
-          "name": "Lifecycle",
-          "events": [
+          "kind": "function",
+          "name": "debounce",
+          "parameters": [
             {
-              "description": "Captures the click event and emits the original event details.",
-              "name": "on-click"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "primaryBtnText",
+              "name": "fn",
               "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "primaryBtnText string",
-              "fieldName": "primaryBtnText"
+                "text": "Function"
+              }
             },
             {
-              "name": "secondaryBtnText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "secondaryBtnText string",
-              "fieldName": "secondaryBtnText"
-            },
-            {
-              "name": "size",
-              "type": {
-                "text": "BUTTON_SIZES"
-              },
-              "description": "Specifies the size of the button.",
-              "fieldName": "size"
+              "name": "ms",
+              "default": "100"
             }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kd-lifecycle",
-          "customElement": true
+          ]
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "Lifecycle",
+          "name": "debounce",
           "declaration": {
-            "name": "Lifecycle",
-            "module": "src/components/lifecycle/lifecycle.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kd-lifecycle",
-          "declaration": {
-            "name": "Lifecycle",
-            "module": "src/components/lifecycle/lifecycle.ts"
+            "name": "debounce",
+            "module": "src/common/helpers/events.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/expandableTile/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "ExpandableTile",
-          "declaration": {
-            "name": "ExpandableTile",
-            "module": "./expandableTile"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/expandableTile/expandableTile.ts",
+      "path": "src/common/helpers/storybook.ts",
       "declarations": [
         {
-          "kind": "class",
-          "description": "Component for expandable tile.",
-          "name": "ExpandableTile",
-          "slots": [
+          "kind": "function",
+          "name": "stringToReactHtml",
+          "parameters": [
             {
-              "description": "Slot for expandable tile content.",
-              "name": "unnamed"
-            },
-            {
-              "description": "Slot for primaryText.",
-              "name": "primaryText"
-            }
-          ],
-          "events": [
-            {
-              "description": "Emits the expanded state when the tile opens/closes.",
-              "name": "on-toggle"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "expanded",
+              "name": "string",
               "type": {
-                "text": "boolean"
+                "text": "String"
+              }
+            }
+          ]
+        },
+        {
+          "kind": "function",
+          "name": "createOptionsArray",
+          "parameters": [
+            {
+              "name": "options",
+              "default": "{}",
+              "type": {
+                "text": "*"
               },
-              "default": "false",
-              "description": "Expanded to view more content",
-              "fieldName": "expanded"
+              "description": " imported enums object"
             }
           ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kd-expandable-tile",
-          "customElement": true
+          "description": "Convert an object to an array of only its values.\nUsed when importing enums in component stories for populating argType dropdowns."
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "ExpandableTile",
+          "name": "stringToReactHtml",
           "declaration": {
-            "name": "ExpandableTile",
-            "module": "src/components/expandableTile/expandableTile.ts"
+            "name": "stringToReactHtml",
+            "module": "src/common/helpers/storybook.ts"
           }
         },
         {
-          "kind": "custom-element-definition",
-          "name": "kd-expandable-tile",
+          "kind": "js",
+          "name": "createOptionsArray",
           "declaration": {
-            "name": "ExpandableTile",
-            "module": "src/components/expandableTile/expandableTile.ts"
+            "name": "createOptionsArray",
+            "module": "src/common/helpers/storybook.ts"
           }
         }
       ]

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2177,6 +2177,34 @@
               "name": "on-click"
             }
           ],
+          "attributes": [
+            {
+              "name": "primaryBtnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "primaryBtnText string",
+              "fieldName": "primaryBtnText"
+            },
+            {
+              "name": "secondaryBtnText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "secondaryBtnText string",
+              "fieldName": "secondaryBtnText"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "BUTTON_SIZES"
+              },
+              "description": "Specifies the size of the button.",
+              "fieldName": "size"
+            }
+          ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2062,6 +2062,203 @@
           }
         }
       ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/sample/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Sample",
+          "declaration": {
+            "name": "Sample",
+            "module": "./sample"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/sample/sample.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Component for sample message.",
+          "name": "Sample",
+          "events": [
+            {
+              "description": "Captures the click event and emits the original event details.",
+              "name": "on-click"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "message",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "message string",
+              "fieldName": "message"
+            },
+            {
+              "kind": "field",
+              "name": "submessage",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "submessage string",
+              "attribute": "submessage"
+            },
+            {
+              "name": "option",
+              "type": {
+                "text": "LINK_TARGETS"
+              },
+              "description": "Defines a target attribute for where to load the URL. Possible options include \"_self\" (default), \"_blank\", \"_parent\", \"_top\"",
+              "fieldName": "target"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-sample",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Sample",
+          "declaration": {
+            "name": "Sample",
+            "module": "src/components/sample/sample.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-sample",
+          "declaration": {
+            "name": "Sample",
+            "module": "src/components/sample/sample.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/lifecycle/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Lifecycle",
+          "declaration": {
+            "name": "Lifecycle",
+            "module": "./lifecycle"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/lifecycle/lifecycle.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Component for lifecycle events.",
+          "name": "Lifecycle",
+          "events": [
+            {
+              "description": "Captures the click event and emits the original event details.",
+              "name": "on-click"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-lifecycle",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Lifecycle",
+          "declaration": {
+            "name": "Lifecycle",
+            "module": "src/components/lifecycle/lifecycle.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-lifecycle",
+          "declaration": {
+            "name": "Lifecycle",
+            "module": "src/components/lifecycle/lifecycle.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/expandableTile/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ExpandableTile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "./expandableTile"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/expandableTile/expandableTile.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Component for expandable tile.",
+          "name": "ExpandableTile",
+          "slots": [
+            {
+              "description": "Slot for expandable tile content.",
+              "name": "unnamed"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-expandable-tile",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "ExpandableTile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "src/components/expandableTile/expandableTile.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-expandable-tile",
+          "declaration": {
+            "name": "ExpandableTile",
+            "module": "src/components/expandableTile/expandableTile.ts"
+          }
+        }
+      ]
     }
   ]
 }

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2261,6 +2261,32 @@
               "name": "unnamed"
             }
           ],
+          "events": [
+            {
+              "description": "Emits the expanded state when the tile opens/closes.",
+              "name": "on-toggle"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "expanded",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Expanded to view more content",
+              "fieldName": "expanded"
+            },
+            {
+              "name": "primaryText",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "primaryText string",
+              "fieldName": "primaryText"
+            }
+          ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -2259,6 +2259,10 @@
             {
               "description": "Slot for expandable tile content.",
               "name": "unnamed"
+            },
+            {
+              "description": "Slot for primaryText.",
+              "name": "primaryText"
             }
           ],
           "events": [
@@ -2276,15 +2280,6 @@
               "default": "false",
               "description": "Expanded to view more content",
               "fieldName": "expanded"
-            },
-            {
-              "name": "primaryText",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "primaryText string",
-              "fieldName": "primaryText"
             }
           ],
           "superclass": {

--- a/custom-elements.json
+++ b/custom-elements.json
@@ -131,6 +131,306 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/components/button/button.ts",
+      "declarations": [
+        {
+          "kind": "class",
+          "description": "Button component.",
+          "name": "Button",
+          "slots": [
+            {
+              "description": "Slot for button text.",
+              "name": "unnamed"
+            },
+            {
+              "description": "Slot for an icon.",
+              "name": "icon"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "description",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "ARIA label for the button for accessibility.",
+              "attribute": "description"
+            },
+            {
+              "kind": "field",
+              "name": "type",
+              "type": {
+                "text": "BUTTON_TYPES"
+              },
+              "description": "Type for the &lt;button&gt; element.",
+              "attribute": "type"
+            },
+            {
+              "kind": "field",
+              "name": "kind",
+              "type": {
+                "text": "BUTTON_KINDS"
+              },
+              "description": "Specifies the visual appearance/kind of the button.",
+              "attribute": "kind"
+            },
+            {
+              "kind": "field",
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Converts the button to an &lt;a&gt; tag if specified.",
+              "attribute": "href"
+            },
+            {
+              "kind": "field",
+              "name": "size",
+              "type": {
+                "text": "BUTTON_SIZES"
+              },
+              "description": "Specifies the size of the button.",
+              "attribute": "size"
+            },
+            {
+              "kind": "field",
+              "name": "iconPosition",
+              "type": {
+                "text": "BUTTON_ICON_POSITION"
+              },
+              "description": "Specifies the position of the icon relative to any button text.",
+              "attribute": "iconPosition"
+            },
+            {
+              "kind": "field",
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the button is disabled.",
+              "attribute": "disabled",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "destructive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the button indicates a destructive action.",
+              "attribute": "destructive",
+              "reflects": true
+            },
+            {
+              "kind": "field",
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Button value.",
+              "attribute": "value"
+            },
+            {
+              "kind": "field",
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Button name.",
+              "attribute": "name"
+            },
+            {
+              "kind": "field",
+              "name": "formmethod",
+              "type": {
+                "text": "any"
+              },
+              "description": "Button formmethod.",
+              "attribute": "formmethod"
+            },
+            {
+              "kind": "method",
+              "name": "handleClick",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "Event"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_testIconOnly",
+              "privacy": "private"
+            },
+            {
+              "kind": "method",
+              "name": "_handleSlotChange",
+              "privacy": "private"
+            }
+          ],
+          "events": [
+            {
+              "description": "Emits the original click event.",
+              "name": "on-click"
+            }
+          ],
+          "attributes": [
+            {
+              "name": "description",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "ARIA label for the button for accessibility.",
+              "fieldName": "description"
+            },
+            {
+              "name": "type",
+              "type": {
+                "text": "BUTTON_TYPES"
+              },
+              "description": "Type for the &lt;button&gt; element.",
+              "fieldName": "type"
+            },
+            {
+              "name": "kind",
+              "type": {
+                "text": "BUTTON_KINDS"
+              },
+              "description": "Specifies the visual appearance/kind of the button.",
+              "fieldName": "kind"
+            },
+            {
+              "name": "href",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Converts the button to an &lt;a&gt; tag if specified.",
+              "fieldName": "href"
+            },
+            {
+              "name": "size",
+              "type": {
+                "text": "BUTTON_SIZES"
+              },
+              "description": "Specifies the size of the button.",
+              "fieldName": "size"
+            },
+            {
+              "name": "iconPosition",
+              "type": {
+                "text": "BUTTON_ICON_POSITION"
+              },
+              "description": "Specifies the position of the icon relative to any button text.",
+              "fieldName": "iconPosition"
+            },
+            {
+              "name": "disabled",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the button is disabled.",
+              "fieldName": "disabled"
+            },
+            {
+              "name": "destructive",
+              "type": {
+                "text": "boolean"
+              },
+              "default": "false",
+              "description": "Determines if the button indicates a destructive action.",
+              "fieldName": "destructive"
+            },
+            {
+              "name": "value",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Button value.",
+              "fieldName": "value"
+            },
+            {
+              "name": "name",
+              "type": {
+                "text": "string"
+              },
+              "default": "''",
+              "description": "Button name.",
+              "fieldName": "name"
+            },
+            {
+              "name": "formmethod",
+              "type": {
+                "text": "any"
+              },
+              "description": "Button formmethod.",
+              "fieldName": "formmethod"
+            }
+          ],
+          "superclass": {
+            "name": "LitElement",
+            "package": "lit"
+          },
+          "tagName": "kd-button",
+          "customElement": true
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Button",
+          "declaration": {
+            "name": "Button",
+            "module": "src/components/button/button.ts"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "kd-button",
+          "declaration": {
+            "name": "Button",
+            "module": "src/components/button/button.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/button/defs.ts",
+      "declarations": [],
+      "exports": []
+    },
+    {
+      "kind": "javascript-module",
+      "path": "src/components/button/index.ts",
+      "declarations": [],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "Button",
+          "declaration": {
+            "name": "Button",
+            "module": "./button"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/accordion/accordion.ts",
       "declarations": [
         {
@@ -549,133 +849,37 @@
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/button/button.ts",
+      "path": "src/components/expandableTile/expandableTile.ts",
       "declarations": [
         {
           "kind": "class",
-          "description": "Button component.",
-          "name": "Button",
+          "description": "Expandable Tile component",
+          "name": "ExpandableTile",
           "slots": [
             {
-              "description": "Slot for button text.",
-              "name": "unnamed"
+              "description": "Slot for expandable tile title.",
+              "name": "title"
             },
             {
-              "description": "Slot for an icon.",
-              "name": "icon"
+              "description": "Slot for expandable tile contents.",
+              "name": "unnamed"
             }
           ],
           "members": [
             {
               "kind": "field",
-              "name": "description",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "ARIA label for the button for accessibility.",
-              "attribute": "description"
-            },
-            {
-              "kind": "field",
-              "name": "type",
-              "type": {
-                "text": "BUTTON_TYPES"
-              },
-              "description": "Type for the &lt;button&gt; element.",
-              "attribute": "type"
-            },
-            {
-              "kind": "field",
-              "name": "kind",
-              "type": {
-                "text": "BUTTON_KINDS"
-              },
-              "description": "Specifies the visual appearance/kind of the button.",
-              "attribute": "kind"
-            },
-            {
-              "kind": "field",
-              "name": "href",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Converts the button to an &lt;a&gt; tag if specified.",
-              "attribute": "href"
-            },
-            {
-              "kind": "field",
-              "name": "size",
-              "type": {
-                "text": "BUTTON_SIZES"
-              },
-              "description": "Specifies the size of the button.",
-              "attribute": "size"
-            },
-            {
-              "kind": "field",
-              "name": "iconPosition",
-              "type": {
-                "text": "BUTTON_ICON_POSITION"
-              },
-              "description": "Specifies the position of the icon relative to any button text.",
-              "attribute": "iconPosition"
-            },
-            {
-              "kind": "field",
-              "name": "disabled",
+              "name": "expanded",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines if the button is disabled.",
-              "attribute": "disabled",
+              "description": "expanded state",
+              "attribute": "expanded",
               "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "destructive",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Determines if the button indicates a destructive action.",
-              "attribute": "destructive",
-              "reflects": true
-            },
-            {
-              "kind": "field",
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Button value.",
-              "attribute": "value"
-            },
-            {
-              "kind": "field",
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Button name.",
-              "attribute": "name"
-            },
-            {
-              "kind": "field",
-              "name": "formmethod",
-              "type": {
-                "text": "any"
-              },
-              "description": "Button formmethod.",
-              "attribute": "formmethod"
             },
             {
               "kind": "method",
-              "name": "handleClick",
+              "name": "_handleClick",
               "privacy": "private",
               "parameters": [
                 {
@@ -688,161 +892,83 @@
             },
             {
               "kind": "method",
-              "name": "_testIconOnly",
+              "name": "_handleKeypress",
+              "privacy": "private",
+              "parameters": [
+                {
+                  "name": "e",
+                  "type": {
+                    "text": "KeyboardEvent"
+                  }
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "_toggleExpanded",
               "privacy": "private"
             },
             {
               "kind": "method",
-              "name": "_handleSlotChange",
+              "name": "_emitToggleEvent",
               "privacy": "private"
             }
           ],
           "events": [
             {
-              "description": "Emits the original click event.",
-              "name": "on-click"
+              "description": "Emits the `expanded` state when tile component open and closes.",
+              "name": "on-toggle"
             }
           ],
           "attributes": [
             {
-              "name": "description",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "ARIA label for the button for accessibility.",
-              "fieldName": "description"
-            },
-            {
-              "name": "type",
-              "type": {
-                "text": "BUTTON_TYPES"
-              },
-              "description": "Type for the &lt;button&gt; element.",
-              "fieldName": "type"
-            },
-            {
-              "name": "kind",
-              "type": {
-                "text": "BUTTON_KINDS"
-              },
-              "description": "Specifies the visual appearance/kind of the button.",
-              "fieldName": "kind"
-            },
-            {
-              "name": "href",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Converts the button to an &lt;a&gt; tag if specified.",
-              "fieldName": "href"
-            },
-            {
-              "name": "size",
-              "type": {
-                "text": "BUTTON_SIZES"
-              },
-              "description": "Specifies the size of the button.",
-              "fieldName": "size"
-            },
-            {
-              "name": "iconPosition",
-              "type": {
-                "text": "BUTTON_ICON_POSITION"
-              },
-              "description": "Specifies the position of the icon relative to any button text.",
-              "fieldName": "iconPosition"
-            },
-            {
-              "name": "disabled",
+              "name": "expanded",
               "type": {
                 "text": "boolean"
               },
               "default": "false",
-              "description": "Determines if the button is disabled.",
-              "fieldName": "disabled"
-            },
-            {
-              "name": "destructive",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "Determines if the button indicates a destructive action.",
-              "fieldName": "destructive"
-            },
-            {
-              "name": "value",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Button value.",
-              "fieldName": "value"
-            },
-            {
-              "name": "name",
-              "type": {
-                "text": "string"
-              },
-              "default": "''",
-              "description": "Button name.",
-              "fieldName": "name"
-            },
-            {
-              "name": "formmethod",
-              "type": {
-                "text": "any"
-              },
-              "description": "Button formmethod.",
-              "fieldName": "formmethod"
+              "description": "expanded state",
+              "fieldName": "expanded"
             }
           ],
           "superclass": {
             "name": "LitElement",
             "package": "lit"
           },
-          "tagName": "kd-button",
+          "tagName": "kd-expandable-tile",
           "customElement": true
         }
       ],
       "exports": [
         {
           "kind": "js",
-          "name": "Button",
+          "name": "ExpandableTile",
           "declaration": {
-            "name": "Button",
-            "module": "src/components/button/button.ts"
+            "name": "ExpandableTile",
+            "module": "src/components/expandableTile/expandableTile.ts"
           }
         },
         {
           "kind": "custom-element-definition",
-          "name": "kd-button",
+          "name": "kd-expandable-tile",
           "declaration": {
-            "name": "Button",
-            "module": "src/components/button/button.ts"
+            "name": "ExpandableTile",
+            "module": "src/components/expandableTile/expandableTile.ts"
           }
         }
       ]
     },
     {
       "kind": "javascript-module",
-      "path": "src/components/button/defs.ts",
-      "declarations": [],
-      "exports": []
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/button/index.ts",
+      "path": "src/components/expandableTile/index.ts",
       "declarations": [],
       "exports": [
         {
           "kind": "js",
-          "name": "Button",
+          "name": "ExpandableTile",
           "declaration": {
-            "name": "Button",
-            "module": "./button"
+            "name": "ExpandableTile",
+            "module": "./expandableTile"
           }
         }
       ]
@@ -1053,132 +1179,6 @@
           "declaration": {
             "name": "Card",
             "module": "./card"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/expandableTile/expandableTile.ts",
-      "declarations": [
-        {
-          "kind": "class",
-          "description": "Expandable Tile component",
-          "name": "ExpandableTile",
-          "slots": [
-            {
-              "description": "The string that displays as title on Tile",
-              "name": "title"
-            },
-            {
-              "description": "The string that displays on the toggle",
-              "name": "unnamed"
-            }
-          ],
-          "members": [
-            {
-              "kind": "field",
-              "name": "expanded",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "expanded state",
-              "attribute": "expanded",
-              "reflects": true
-            },
-            {
-              "kind": "method",
-              "name": "_handleClick",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "Event"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_handleKeypress",
-              "privacy": "private",
-              "parameters": [
-                {
-                  "name": "e",
-                  "type": {
-                    "text": "KeyboardEvent"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "method",
-              "name": "_toggleExpanded",
-              "privacy": "private"
-            },
-            {
-              "kind": "method",
-              "name": "_emitToggleEvent",
-              "privacy": "private"
-            }
-          ],
-          "events": [
-            {
-              "description": "Emits the `expanded` state when tile component open and closes.",
-              "name": "on-toggle"
-            }
-          ],
-          "attributes": [
-            {
-              "name": "expanded",
-              "type": {
-                "text": "boolean"
-              },
-              "default": "false",
-              "description": "expanded state",
-              "fieldName": "expanded"
-            }
-          ],
-          "superclass": {
-            "name": "LitElement",
-            "package": "lit"
-          },
-          "tagName": "kd-expandable-tile",
-          "customElement": true
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "ExpandableTile",
-          "declaration": {
-            "name": "ExpandableTile",
-            "module": "src/components/expandableTile/expandableTile.ts"
-          }
-        },
-        {
-          "kind": "custom-element-definition",
-          "name": "kd-expandable-tile",
-          "declaration": {
-            "name": "ExpandableTile",
-            "module": "src/components/expandableTile/expandableTile.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/components/expandableTile/index.ts",
-      "declarations": [],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "ExpandableTile",
-          "declaration": {
-            "name": "ExpandableTile",
-            "module": "./expandableTile"
           }
         }
       ]
@@ -1788,6 +1788,31 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/common/defs/breakpoints.ts",
+      "declarations": [
+        {
+          "kind": "variable",
+          "name": "BREAKPOINTS",
+          "type": {
+            "text": "object"
+          },
+          "default": "{\n  SM: 'sm',\n  MD: 'md',\n  LG: 'lg',\n  XL: 'xl',\n  MAX: 'max',\n}",
+          "description": "Breakpoint values defined in variable: --kd-current-breakpoint\nUsed for conditional logic and/or rendering in component JS\nby matching the current breakpoint to one of these values."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "BREAKPOINTS",
+          "declaration": {
+            "name": "BREAKPOINTS",
+            "module": "src/common/defs/breakpoints.ts"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/components/splitButton/defs.ts",
       "declarations": [],
       "exports": []
@@ -2344,31 +2369,6 @@
           "declaration": {
             "name": "SplitButtonOption",
             "module": "src/components/splitButton/splitButtonOption.ts"
-          }
-        }
-      ]
-    },
-    {
-      "kind": "javascript-module",
-      "path": "src/common/defs/breakpoints.ts",
-      "declarations": [
-        {
-          "kind": "variable",
-          "name": "BREAKPOINTS",
-          "type": {
-            "text": "object"
-          },
-          "default": "{\n  SM: 'sm',\n  MD: 'md',\n  LG: 'lg',\n  XL: 'xl',\n  MAX: 'max',\n}",
-          "description": "Breakpoint values defined in variable: --kd-current-breakpoint\nUsed for conditional logic and/or rendering in component JS\nby matching the current breakpoint to one of these values."
-        }
-      ],
-      "exports": [
-        {
-          "kind": "js",
-          "name": "BREAKPOINTS",
-          "declaration": {
-            "name": "BREAKPOINTS",
-            "module": "src/common/defs/breakpoints.ts"
           }
         }
       ]

--- a/src/components/expandableTile/ExpandableTile.stories.js
+++ b/src/components/expandableTile/ExpandableTile.stories.js
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { action } from '@storybook/addon-actions';
 import './index';
 
 export default {
@@ -12,11 +13,21 @@ export default {
   },
 };
 
+const args = {
+  expanded: false,
+  primaryText: 'Hello!! I am main content',
+};
+
 export const ExpandableTile = {
-  render: () =>
+  args,
+  render: (args) =>
     html`
       <kd-expandable-tile
-        >Hello!! I am an expandable content
+        .expanded=${args.expanded}
+        primaryText=${args.primaryText}
+        @on-toggle=${(e) => action(e.type)(e)}
+      >
+        Hello!! I am an expandable content
       </kd-expandable-tile>
     `,
 };

--- a/src/components/expandableTile/ExpandableTile.stories.js
+++ b/src/components/expandableTile/ExpandableTile.stories.js
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { action } from '@storybook/addon-actions';
+import { fn } from '@storybook/test';
 import './index';
 
 export default {
@@ -16,6 +16,8 @@ export default {
 const args = {
   expanded: false,
   primaryText: 'Title text goes here...',
+  unnamed: 'Hello!! I am an expandable content',
+  'on-toggle': fn(),
 };
 
 export const ExpandableTile = {
@@ -24,10 +26,10 @@ export const ExpandableTile = {
     html`
       <kd-expandable-tile
         .expanded=${args.expanded}
-        @on-toggle=${(e) => action(e.type)(e)}
+        @on-toggle=${args['on-toggle']}
       >
         <span slot="title"> ${args.primaryText}</span>
-        Hello!! I am an expandable content
+        ${args.unnamed}
       </kd-expandable-tile>
     `,
 };

--- a/src/components/expandableTile/ExpandableTile.stories.js
+++ b/src/components/expandableTile/ExpandableTile.stories.js
@@ -15,7 +15,7 @@ export default {
 
 const args = {
   expanded: false,
-  primaryText: 'Hello!! I am main content',
+  primaryText: 'Title text goes here...',
 };
 
 export const ExpandableTile = {
@@ -24,9 +24,9 @@ export const ExpandableTile = {
     html`
       <kd-expandable-tile
         .expanded=${args.expanded}
-        primaryText=${args.primaryText}
         @on-toggle=${(e) => action(e.type)(e)}
       >
+        <span slot="title"> ${args.primaryText}</span>
         Hello!! I am an expandable content
       </kd-expandable-tile>
     `,

--- a/src/components/expandableTile/ExpandableTile.stories.js
+++ b/src/components/expandableTile/ExpandableTile.stories.js
@@ -15,7 +15,7 @@ export default {
 
 const args = {
   expanded: false,
-  primaryText: 'Title text goes here...',
+  title: 'Title text goes here...',
   unnamed: 'Hello!! I am an expandable content',
   'on-toggle': fn(),
 };
@@ -28,7 +28,7 @@ export const ExpandableTile = {
         .expanded=${args.expanded}
         @on-toggle=${args['on-toggle']}
       >
-        <span slot="title"> ${args.primaryText}</span>
+        <span slot="title"> ${args.title}</span>
         ${args.unnamed}
       </kd-expandable-tile>
     `,

--- a/src/components/expandableTile/ExpandableTile.stories.js
+++ b/src/components/expandableTile/ExpandableTile.stories.js
@@ -1,0 +1,22 @@
+import { html } from 'lit';
+import './index';
+
+export default {
+  title: 'Components/Expandale Tile',
+  component: 'kd-expandable-tile',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: '',
+    },
+  },
+};
+
+export const ExpandableTile = {
+  render: () =>
+    html`
+      <kd-expandable-tile
+        >Hello!! I am an expandable content
+      </kd-expandable-tile>
+    `,
+};

--- a/src/components/expandableTile/ExpandableTile.stories.js
+++ b/src/components/expandableTile/ExpandableTile.stories.js
@@ -2,7 +2,7 @@ import { html } from 'lit';
 import './index';
 
 export default {
-  title: 'Components/Expandale Tile',
+  title: 'Components/Practise/Expandale Tile',
   component: 'kd-expandable-tile',
   parameters: {
     design: {

--- a/src/components/expandableTile/expandableTile.scss
+++ b/src/components/expandableTile/expandableTile.scss
@@ -36,7 +36,7 @@ button {
   }
 
   &_tile {
-    @include typography.type-body-02;
+    @include typography.type-headline-08;
     border-radius: 5px;
     padding: 10px;
     margin: 10px;

--- a/src/components/expandableTile/expandableTile.scss
+++ b/src/components/expandableTile/expandableTile.scss
@@ -11,6 +11,7 @@ button {
   text-align: start;
   border: none;
   border-radius: 5px;
+  padding: 0;
   background-color: var(--kd-color-background-accent-subtle);
 }
 
@@ -22,20 +23,31 @@ button {
   &:hover {
     background: var(--kd-color-background-accent-ui);
   }
-  &_icon {
-    transform: rotate(-180deg);
+  &_container {
+    display: flex;
   }
+  &_svgIcon {
+    display: flex;
+    justify-content: center;
+    flex-direction: column;
+    margin-left: auto;
+    transition: transform 150ms ease-out;
+    color: var(--kd-color-text-link);
+  }
+
   &_tile {
     @include typography.type-body-02;
     border-radius: 5px;
     padding: 10px;
-    margin-bottom: 10px;
+    margin: 10px;
     background-color: var(--kd-color-background-accent-ui-light);
+  }
+  &_icon {
+    transform: rotate(-180deg);
   }
   &_content {
     display: none;
     padding: 10px;
-    height: 330px;
   }
 }
 

--- a/src/components/expandableTile/expandableTile.scss
+++ b/src/components/expandableTile/expandableTile.scss
@@ -48,6 +48,8 @@ button {
   &_content {
     display: none;
     padding: 10px;
+    height: 70px;
+    overflow-y: auto;
   }
 }
 

--- a/src/components/expandableTile/expandableTile.scss
+++ b/src/components/expandableTile/expandableTile.scss
@@ -1,0 +1,43 @@
+@use '../../scss/mixins/typography';
+
+:host {
+  /* web components are display: inline; by default */
+  display: block;
+}
+
+button {
+  width: 100%;
+  text-align: start;
+  border: none;
+  border-radius: 5px;
+  background-color: var(--kd-color-darkstone-10);
+}
+
+.expanded--tile {
+  &:focus {
+    outline: 2px solid #0f62fe;
+    outline-offset: -2px;
+  }
+  &:hover {
+    background: #e8e8e8;
+  }
+  &_icon {
+    transform: rotate(-180deg);
+  }
+  &_tile {
+    @include typography.type-body-02;
+    border-radius: 5px;
+    padding: 10px;
+    margin-bottom: 10px;
+    background-color: aliceblue;
+  }
+  &_content {
+    display: none;
+    padding: 10px;
+    height: 330px;
+  }
+}
+
+.expanded .expanded--tile_content {
+  display: block;
+}

--- a/src/components/expandableTile/expandableTile.scss
+++ b/src/components/expandableTile/expandableTile.scss
@@ -1,3 +1,4 @@
+@use '../../scss/global';
 @use '../../scss/mixins/typography';
 
 :host {
@@ -10,16 +11,16 @@ button {
   text-align: start;
   border: none;
   border-radius: 5px;
-  background-color: var(--kd-color-darkstone-10);
+  background-color: var(--kd-color-background-accent-subtle);
 }
 
 .expanded--tile {
   &:focus {
-    outline: 2px solid #0f62fe;
+    outline: 2px solid var(--kd-color-background-focus);
     outline-offset: -2px;
   }
   &:hover {
-    background: #e8e8e8;
+    background: var(--kd-color-background-accent-ui);
   }
   &_icon {
     transform: rotate(-180deg);
@@ -29,7 +30,7 @@ button {
     border-radius: 5px;
     padding: 10px;
     margin-bottom: 10px;
-    background-color: aliceblue;
+    background-color: var(--kd-color-background-accent-ui-light);
   }
   &_content {
     display: none;

--- a/src/components/expandableTile/expandableTile.ts
+++ b/src/components/expandableTile/expandableTile.ts
@@ -75,12 +75,18 @@ export class ExpandableTile extends LitElement {
         @click="${(e: Event) => this._handleClick(e)}"
         @keypress="${(e: KeyboardEvent) => this._handleKeypress(e)}"
       >
-        <kd-icon
-          class="${this.expanded ? 'expanded--tile_icon' : ''}"
-          .icon="${ChevronDown16}"
-        ></kd-icon>
         <div class="expanded--tile_tile ${this.expanded ? 'expanded' : ''}">
-          <div>${this.primaryText}</div>
+          <div class="expanded--tile_container">
+            <div>
+              <slot name="title"></slot>
+            </div>
+            <div class="expanded--tile_svgIcon">
+              <kd-icon
+                class="${this.expanded ? 'expanded--tile_icon' : ''}"
+                .icon="${ChevronDown16}"
+              ></kd-icon>
+            </div>
+          </div>
           <div class="expanded--tile_content">
             <slot></slot>
           </div>

--- a/src/components/expandableTile/expandableTile.ts
+++ b/src/components/expandableTile/expandableTile.ts
@@ -5,37 +5,19 @@ import ChevronDown from '@carbon/icons/es/chevron--down/24';
 import '../icon';
 
 /**
- * ExpandableTile component
- *
- * @export
- * @class ExpandableTile
- * @typedef {ExpandableTile}
- * @extends {LitElement}
+ * Expandable Tile component
+ * @fires on-toggle - Emits the `expanded` state when tile component open and closes.
+ * @slot title - The string that displays as title on Tile
+ * @slot unnamed - The string that displays on the toggle
  */
 @customElement('kd-expandable-tile')
 export class ExpandableTile extends LitElement {
   /**
-   * ExpandableTile expanded state
-   *
-   * @type {boolean}
+   * expanded state
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
-  /**
-   * ExpandableTile primary text
-   *
-   * @type {string}
-   */
-  @property({ type: String })
-  primaryText = '';
-
-  /**
-   * @inheritdoc
-   *
-   * @static
-   * @type {*}
-   */
   static override styles = Styles;
 
   private _handleClick(e: Event) {
@@ -63,11 +45,6 @@ export class ExpandableTile extends LitElement {
     this.dispatchEvent(event);
   }
 
-  /**
-   * @inheritdoc
-   *
-   * @returns {*}
-   */
   override render() {
     return html`
       <button

--- a/src/components/expandableTile/expandableTile.ts
+++ b/src/components/expandableTile/expandableTile.ts
@@ -1,11 +1,11 @@
 import { html, LitElement } from 'lit';
 import Styles from './expandableTile.scss';
 import { customElement, property } from 'lit/decorators.js';
-import ChevronDown16 from '@carbon/icons/es/chevron--down/16';
+import ChevronDown from '@carbon/icons/es/chevron--down/24';
 import '../icon';
 
 /**
- * Description placeholder
+ * ExpandableTile component
  *
  * @export
  * @class ExpandableTile
@@ -15,7 +15,7 @@ import '../icon';
 @customElement('kd-expandable-tile')
 export class ExpandableTile extends LitElement {
   /**
-   * Description placeholder
+   * ExpandableTile expanded state
    *
    * @type {boolean}
    */
@@ -23,7 +23,7 @@ export class ExpandableTile extends LitElement {
   expanded = false;
 
   /**
-   * Description placeholder
+   * ExpandableTile primary text
    *
    * @type {string}
    */
@@ -83,7 +83,7 @@ export class ExpandableTile extends LitElement {
             <div class="expanded--tile_svgIcon">
               <kd-icon
                 class="${this.expanded ? 'expanded--tile_icon' : ''}"
-                .icon="${ChevronDown16}"
+                .icon="${ChevronDown}"
               ></kd-icon>
             </div>
           </div>

--- a/src/components/expandableTile/expandableTile.ts
+++ b/src/components/expandableTile/expandableTile.ts
@@ -7,8 +7,8 @@ import '../icon';
 /**
  * Expandable Tile component
  * @fires on-toggle - Emits the `expanded` state when tile component open and closes.
- * @slot title - The string that displays as title on Tile
- * @slot unnamed - The string that displays on the toggle
+ * @slot title - Slot for expandable tile title.
+ * @slot unnamed - Slot for expandable tile contents.
  */
 @customElement('kd-expandable-tile')
 export class ExpandableTile extends LitElement {

--- a/src/components/expandableTile/expandableTile.ts
+++ b/src/components/expandableTile/expandableTile.ts
@@ -1,0 +1,40 @@
+import { html, LitElement } from 'lit';
+import Styles from './expandableTile.scss';
+import { customElement, property } from 'lit/decorators.js';
+import ChevronDown16 from '@carbon/icons/es/chevron--down/16';
+import '../icon';
+
+@customElement('kd-expandable-tile')
+export class ExpandableTile extends LitElement {
+  @property({ type: Boolean, reflect: true })
+  expanded = false;
+
+  static override styles = Styles;
+
+  toggleExpanded() {
+    this.expanded = !this.expanded;
+  }
+
+  override render() {
+    return html`
+      <button class="expanded--tile" @click=${this.toggleExpanded}>
+        <kd-icon
+          class="${this.expanded ? 'expanded--tile_icon' : ''}"
+          .icon="${ChevronDown16}"
+        ></kd-icon>
+        <div class="expanded--tile_tile ${this.expanded ? 'expanded' : ''}">
+          <div>Click to expand....</div>
+          <div class="expanded--tile_content">
+            <slot></slot>
+          </div>
+        </div>
+      </button>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'kd-expandable-tile': ExpandableTile;
+  }
+}

--- a/src/components/expandableTile/expandableTile.ts
+++ b/src/components/expandableTile/expandableTile.ts
@@ -4,26 +4,83 @@ import { customElement, property } from 'lit/decorators.js';
 import ChevronDown16 from '@carbon/icons/es/chevron--down/16';
 import '../icon';
 
+/**
+ * Description placeholder
+ *
+ * @export
+ * @class ExpandableTile
+ * @typedef {ExpandableTile}
+ * @extends {LitElement}
+ */
 @customElement('kd-expandable-tile')
 export class ExpandableTile extends LitElement {
+  /**
+   * Description placeholder
+   *
+   * @type {boolean}
+   */
   @property({ type: Boolean, reflect: true })
   expanded = false;
 
+  /**
+   * Description placeholder
+   *
+   * @type {string}
+   */
+  @property({ type: String })
+  primaryText = '';
+
+  /**
+   * @inheritdoc
+   *
+   * @static
+   * @type {*}
+   */
   static override styles = Styles;
 
-  toggleExpanded() {
-    this.expanded = !this.expanded;
+  private _handleClick(e: Event) {
+    e.preventDefault();
+    this._toggleExpanded();
   }
 
+  private _handleKeypress(e: KeyboardEvent) {
+    e.preventDefault();
+    if (e.key == ' ' || e.key == 'Enter') this._toggleExpanded();
+  }
+
+  private _toggleExpanded() {
+    this.expanded = !this.expanded;
+    this._emitToggleEvent();
+  }
+
+  private _emitToggleEvent() {
+    const event = new CustomEvent('on-toggle', {
+      bubbles: true,
+      composed: true,
+      detail: { expanded: this.expanded },
+    });
+    console.log('_emitToggleEvent', event);
+    this.dispatchEvent(event);
+  }
+
+  /**
+   * @inheritdoc
+   *
+   * @returns {*}
+   */
   override render() {
     return html`
-      <button class="expanded--tile" @click=${this.toggleExpanded}>
+      <button
+        class="expanded--tile"
+        @click="${(e: Event) => this._handleClick(e)}"
+        @keypress="${(e: KeyboardEvent) => this._handleKeypress(e)}"
+      >
         <kd-icon
           class="${this.expanded ? 'expanded--tile_icon' : ''}"
           .icon="${ChevronDown16}"
         ></kd-icon>
         <div class="expanded--tile_tile ${this.expanded ? 'expanded' : ''}">
-          <div>Click to expand....</div>
+          <div>${this.primaryText}</div>
           <div class="expanded--tile_content">
             <slot></slot>
           </div>

--- a/src/components/expandableTile/index.ts
+++ b/src/components/expandableTile/index.ts
@@ -1,0 +1,1 @@
+export { ExpandableTile } from './expandableTile';

--- a/src/components/lifecycle/Lifecycle.stories.js
+++ b/src/components/lifecycle/Lifecycle.stories.js
@@ -1,8 +1,13 @@
 import { html } from 'lit';
 import './index';
 
+import { BUTTON_SIZES } from '../button/defs';
+import { createOptionsArray } from '../../common/helpers/storybook';
+
+const createSelectOptions = (defs) => [null, ...createOptionsArray(defs)];
+
 export default {
-  title: 'Components/Lifecycle Lit Component',
+  title: 'Components/Practise/Lifecycle Lit Component',
   component: 'kd-lifecycle',
   parameters: {
     design: {
@@ -10,8 +15,30 @@ export default {
       url: '',
     },
   },
+  argTypes: {
+    size: {
+      options: createSelectOptions(BUTTON_SIZES),
+      control: { type: 'select', labels: { null: BUTTON_SIZES.MEDIUM } },
+      table: {
+        defaultValue: { summary: BUTTON_SIZES.MEDIUM },
+      },
+    },
+  },
+};
+
+const args = {
+  size: 'medium',
+  primaryBtnText: 'Increment Counter',
+  secondaryBtnText: 'Decrement Counter',
 };
 
 export const Lifecycle = {
-  render: () => html` <kd-lifecycle></kd-lifecycle> `,
+  args,
+  render: (args) => html`
+    <kd-lifecycle
+      size=${args.size}
+      primaryBtnText=${args.primaryBtnText}
+      secondaryBtnText=${args.secondaryBtnText}
+    ></kd-lifecycle>
+  `,
 };

--- a/src/components/lifecycle/Lifecycle.stories.js
+++ b/src/components/lifecycle/Lifecycle.stories.js
@@ -28,6 +28,7 @@ export default {
 
 const args = {
   size: 'medium',
+  counter: 0,
   primaryBtnText: 'Increment Counter',
   secondaryBtnText: 'Decrement Counter',
 };
@@ -37,6 +38,7 @@ export const Lifecycle = {
   render: (args) => html`
     <kd-lifecycle
       size=${args.size}
+      counter=${args.counter}
       primaryBtnText=${args.primaryBtnText}
       secondaryBtnText=${args.secondaryBtnText}
     ></kd-lifecycle>

--- a/src/components/lifecycle/Lifecycle.stories.js
+++ b/src/components/lifecycle/Lifecycle.stories.js
@@ -1,0 +1,17 @@
+import { html } from 'lit';
+import './index';
+
+export default {
+  title: 'Components/Lifecycle Lit Component',
+  component: 'kd-lifecycle',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: '',
+    },
+  },
+};
+
+export const Lifecycle = {
+  render: () => html` <kd-lifecycle></kd-lifecycle> `,
+};

--- a/src/components/lifecycle/index.ts
+++ b/src/components/lifecycle/index.ts
@@ -1,0 +1,1 @@
+export { LitLifecycle } from './lifecycle';

--- a/src/components/lifecycle/lifecycle.scss
+++ b/src/components/lifecycle/lifecycle.scss
@@ -1,0 +1,13 @@
+@use '../../scss/global';
+
+:host {
+  /* web components are display: inline; by default */
+  display: block;
+}
+
+div {
+  padding: 16px;
+  border: 1px solid var(--kd-color-cloud-20);
+  border-radius: 4px;
+  background-color: var(--kd-color-darkstone-10);
+}

--- a/src/components/lifecycle/lifecycle.ts
+++ b/src/components/lifecycle/lifecycle.ts
@@ -4,37 +4,84 @@ import Styles from './lifecycle.scss';
 import '../button/button';
 import { BUTTON_SIZES } from '../button/defs';
 
+/**
+ * LitLifecycle component
+ *
+ * @export
+ * @class LitLifecycle
+ * @typedef {LitLifecycle}
+ * @extends {LitElement}
+ */
 @customElement('kd-lifecycle')
 export class LitLifecycle extends LitElement {
+  /**
+   * Counter state
+   *
+   * @type {number}
+   */
   @property({ type: Number }) counter = 0;
 
+  /**
+   * Button size small, medium, large
+   *
+   * @type {BUTTON_SIZES}
+   */
   @property({ type: String })
   size: BUTTON_SIZES = BUTTON_SIZES.SMALL;
 
+  /**
+   * primaryBtnText
+   *
+   * @type {string}
+   */
   @property({ type: String })
   primaryBtnText = '';
 
+  /**
+   * secondaryBtnText
+   *
+   * @type {string}
+   */
   @property({ type: String })
   secondaryBtnText = '';
 
+  /**
+   * @inheritdoc
+   *
+   * @static
+   * @type {*}
+   */
   static override styles = Styles;
+  /**
+   * Creates an instance of LitLifecycle.
+   *
+   * @constructor
+   */
   constructor() {
     super();
     console.log('Constructor: Component is being created');
   }
 
+  /** @inheritdoc */
   override connectedCallback() {
     super.connectedCallback();
     console.log('ConnectedCallback: Component is added to the DOM');
     //set up additional listeners or logic here
   }
 
+  /** @inheritdoc */
   override disconnectedCallback() {
     console.log('DisconnectedCallback: Component is removed from the DOM');
     //Clean up resources or listeners here
     super.disconnectedCallback();
   }
 
+  /**
+   * @inheritdoc
+   *
+   * @param {Map<string | number | symbol, unknown>} changedProperties
+   * @returns {boolean}
+   */
   override shouldUpdate(
     changedProperties: Map<string | number | symbol, unknown>
   ): boolean {
@@ -44,6 +91,11 @@ export class LitLifecycle extends LitElement {
     // Return true to update, false to skip the update
   }
 
+  /**
+   * @inheritdoc
+   *
+   * @param {Map<string | number | symbol, unknown>} changedProperties
+   */
   override willUpdate(
     changedProperties: Map<string | number | symbol, unknown>
   ) {
@@ -52,12 +104,22 @@ export class LitLifecycle extends LitElement {
     // Implement logic to run before the update
   }
 
+  /**
+   * @inheritdoc
+   *
+   * @param {Map<string | number | symbol, unknown>} changedProperties
+   */
   override update(changedProperties: Map<string | number | symbol, unknown>) {
     console.log('Update: During the update process');
     super.update(changedProperties);
     // Optionally request updates or perform other tasks here
   }
 
+  /**
+   * @inheritdoc
+   *
+   * @returns {*}
+   */
   override render() {
     console.log('Render: Rendering the component');
     return html`
@@ -77,16 +139,23 @@ export class LitLifecycle extends LitElement {
     `;
   }
 
+  /**
+   * @inheritdoc
+   *
+   * @param {Map<string | number | symbol, unknown>} changedProperties
+   */
   override updated(changedProperties: Map<string | number | symbol, unknown>) {
     console.log('Updated: After the component has updated');
     super.updated(changedProperties);
   }
 
+  /** Description placeholder */
   incrementCounter() {
     console.log('IncrementCounter: Incrementing counter');
     this.counter += 1;
   }
 
+  /** Description placeholder */
   decrementCounter() {
     console.log('DecrementCounter: Decrementing counter');
     if (this.counter > 0) {

--- a/src/components/lifecycle/lifecycle.ts
+++ b/src/components/lifecycle/lifecycle.ts
@@ -6,82 +6,51 @@ import { BUTTON_SIZES } from '../button/defs';
 
 /**
  * LitLifecycle component
- *
- * @export
- * @class LitLifecycle
- * @typedef {LitLifecycle}
- * @extends {LitElement}
  */
 @customElement('kd-lifecycle')
 export class LitLifecycle extends LitElement {
   /**
-   * Counter state
-   *
-   * @type {number}
+   * Counter initial state
    */
   @property({ type: Number }) counter = 0;
 
   /**
-   * Button size small, medium, large
-   *
-   * @type {BUTTON_SIZES}
+   * Button size small, medium, large default small
    */
   @property({ type: String })
   size: BUTTON_SIZES = BUTTON_SIZES.SMALL;
 
   /**
-   * primaryBtnText
-   *
-   * @type {string}
+   * primaryBtnText.
    */
   @property({ type: String })
   primaryBtnText = '';
 
   /**
-   * secondaryBtnText
-   *
-   * @type {string}
+   * secondaryBtnText.
    */
   @property({ type: String })
   secondaryBtnText = '';
 
-  /**
-   * @inheritdoc
-   *
-   * @static
-   * @type {*}
-   */
   static override styles = Styles;
-  /**
-   * Creates an instance of LitLifecycle.
-   *
-   * @constructor
-   */
+
   constructor() {
     super();
     console.log('Constructor: Component is being created');
   }
 
-  /** @inheritdoc */
   override connectedCallback() {
     super.connectedCallback();
     console.log('ConnectedCallback: Component is added to the DOM');
     //set up additional listeners or logic here
   }
 
-  /** @inheritdoc */
   override disconnectedCallback() {
     console.log('DisconnectedCallback: Component is removed from the DOM');
     //Clean up resources or listeners here
     super.disconnectedCallback();
   }
 
-  /**
-   * @inheritdoc
-   *
-   * @param {Map<string | number | symbol, unknown>} changedProperties
-   * @returns {boolean}
-   */
   override shouldUpdate(
     changedProperties: Map<string | number | symbol, unknown>
   ): boolean {
@@ -91,11 +60,6 @@ export class LitLifecycle extends LitElement {
     // Return true to update, false to skip the update
   }
 
-  /**
-   * @inheritdoc
-   *
-   * @param {Map<string | number | symbol, unknown>} changedProperties
-   */
   override willUpdate(
     changedProperties: Map<string | number | symbol, unknown>
   ) {
@@ -104,22 +68,12 @@ export class LitLifecycle extends LitElement {
     // Implement logic to run before the update
   }
 
-  /**
-   * @inheritdoc
-   *
-   * @param {Map<string | number | symbol, unknown>} changedProperties
-   */
   override update(changedProperties: Map<string | number | symbol, unknown>) {
     console.log('Update: During the update process');
     super.update(changedProperties);
     // Optionally request updates or perform other tasks here
   }
 
-  /**
-   * @inheritdoc
-   *
-   * @returns {*}
-   */
   override render() {
     console.log('Render: Rendering the component');
     return html`
@@ -129,7 +83,7 @@ export class LitLifecycle extends LitElement {
           >${this.primaryBtnText}</kd-button
         >
         <kd-button
-          ?disabled=${this.counter === 0}
+          ?disabled=${this.counter <= 0}
           destructive
           size=${this.size}
           @click="${this.decrementCounter}"
@@ -139,23 +93,16 @@ export class LitLifecycle extends LitElement {
     `;
   }
 
-  /**
-   * @inheritdoc
-   *
-   * @param {Map<string | number | symbol, unknown>} changedProperties
-   */
   override updated(changedProperties: Map<string | number | symbol, unknown>) {
     console.log('Updated: After the component has updated');
     super.updated(changedProperties);
   }
 
-  /** Description placeholder */
   incrementCounter() {
     console.log('IncrementCounter: Incrementing counter');
     this.counter += 1;
   }
 
-  /** Description placeholder */
   decrementCounter() {
     console.log('DecrementCounter: Decrementing counter');
     if (this.counter > 0) {

--- a/src/components/lifecycle/lifecycle.ts
+++ b/src/components/lifecycle/lifecycle.ts
@@ -1,0 +1,98 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import Styles from './lifecycle.scss';
+import '../button/button';
+
+@customElement('kd-lifecycle')
+export class LitLifecycle extends LitElement {
+  @property({ type: Number }) counter = 0;
+
+  static override styles = Styles;
+  constructor() {
+    super();
+    console.log('Constructor: Component is being created');
+    this.counter = 0; // Initial property value
+  }
+
+  override connectedCallback() {
+    super.connectedCallback();
+    console.log('ConnectedCallback: Component is added to the DOM');
+    //set up additional listeners or logic here
+  }
+
+  override disconnectedCallback() {
+    console.log('DisconnectedCallback: Component is removed from the DOM');
+    //Clean up resources or listeners here
+    super.disconnectedCallback();
+  }
+
+  override shouldUpdate(
+    changedProperties: Map<string | number | symbol, unknown>
+  ): boolean {
+    console.log('ShouldUpdate: Check if the component should update');
+    return super.shouldUpdate(changedProperties);
+    // Implement logic to decide if the component should update
+    // Return true to update, false to skip the update
+  }
+
+  override willUpdate(
+    changedProperties: Map<string | number | symbol, unknown>
+  ) {
+    console.log('WillUpdate: Before the component updates');
+    super.willUpdate(changedProperties);
+    // Implement logic to run before the update
+  }
+
+  override update(changedProperties: Map<string | number | symbol, unknown>) {
+    console.log('Update: During the update process');
+    super.update(changedProperties);
+    // Optionally request updates or perform other tasks here
+  }
+
+  override render() {
+    console.log('Render: Rendering the component');
+    return html`
+      <div>
+        <h2>Lifecycle Component</h2>
+        <p>Counter: ${this.counter}</p>
+        <kd-button @click="${this.incrementCounter}"
+          >Increment Counter</kd-button
+        >
+        <kd-button
+          ?disabled=${this.counter === 0}
+          destructive
+          @click="${this.decrementCounter}"
+          >Decrement Counter</kd-button
+        >
+      </div>
+    `;
+  }
+
+  override updated(changedProperties: Map<string | number | symbol, unknown>) {
+    console.log('Updated: After the component has updated');
+    super.updated(changedProperties);
+    // Implement logic to run after the update
+  }
+
+  incrementCounter() {
+    console.log('IncrementCounter: Incrementing counter');
+    this.counter += 1;
+    // Request an update explicitly (optional)
+    this.requestUpdate('counter', this.counter - 1);
+  }
+
+  decrementCounter() {
+    console.log('DecrementCounter: Decrementing counter');
+    if (this.counter > 0) {
+      this.counter -= 1;
+      // Request an update explicitly (optional)
+      this.requestUpdate('counter', this.counter + 1);
+    }
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'kd-lifecycle': LitLifecycle;
+  }
+}

--- a/src/components/lifecycle/lifecycle.ts
+++ b/src/components/lifecycle/lifecycle.ts
@@ -2,10 +2,21 @@ import { LitElement, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import Styles from './lifecycle.scss';
 import '../button/button';
+import { BUTTON_SIZES } from '../button/defs';
 
 @customElement('kd-lifecycle')
 export class LitLifecycle extends LitElement {
   @property({ type: Number }) counter = 0;
+
+  /** Specifies the size of the button. */
+  @property({ type: String })
+  size: BUTTON_SIZES = BUTTON_SIZES.SMALL;
+
+  @property({ type: String })
+  primaryBtnText = '';
+
+  @property({ type: String })
+  secondaryBtnText = '';
 
   static override styles = Styles;
   constructor() {
@@ -55,14 +66,15 @@ export class LitLifecycle extends LitElement {
       <div>
         <h2>Lifecycle Component</h2>
         <p>Counter: ${this.counter}</p>
-        <kd-button @click="${this.incrementCounter}"
-          >Increment Counter</kd-button
+        <kd-button size=${this.size} @click="${this.incrementCounter}"
+          >${this.primaryBtnText}</kd-button
         >
         <kd-button
           ?disabled=${this.counter === 0}
           destructive
+          size=${this.size}
           @click="${this.decrementCounter}"
-          >Decrement Counter</kd-button
+          >${this.secondaryBtnText}</kd-button
         >
       </div>
     `;

--- a/src/components/lifecycle/lifecycle.ts
+++ b/src/components/lifecycle/lifecycle.ts
@@ -8,7 +8,6 @@ import { BUTTON_SIZES } from '../button/defs';
 export class LitLifecycle extends LitElement {
   @property({ type: Number }) counter = 0;
 
-  /** Specifies the size of the button. */
   @property({ type: String })
   size: BUTTON_SIZES = BUTTON_SIZES.SMALL;
 
@@ -22,7 +21,6 @@ export class LitLifecycle extends LitElement {
   constructor() {
     super();
     console.log('Constructor: Component is being created');
-    this.counter = 0; // Initial property value
   }
 
   override connectedCallback() {
@@ -64,7 +62,6 @@ export class LitLifecycle extends LitElement {
     console.log('Render: Rendering the component');
     return html`
       <div>
-        <h2>Lifecycle Component</h2>
         <p>Counter: ${this.counter}</p>
         <kd-button size=${this.size} @click="${this.incrementCounter}"
           >${this.primaryBtnText}</kd-button
@@ -83,22 +80,17 @@ export class LitLifecycle extends LitElement {
   override updated(changedProperties: Map<string | number | symbol, unknown>) {
     console.log('Updated: After the component has updated');
     super.updated(changedProperties);
-    // Implement logic to run after the update
   }
 
   incrementCounter() {
     console.log('IncrementCounter: Incrementing counter');
     this.counter += 1;
-    // Request an update explicitly (optional)
-    this.requestUpdate('counter', this.counter - 1);
   }
 
   decrementCounter() {
     console.log('DecrementCounter: Decrementing counter');
     if (this.counter > 0) {
       this.counter -= 1;
-      // Request an update explicitly (optional)
-      this.requestUpdate('counter', this.counter + 1);
     }
   }
 }

--- a/src/components/sample/Sample.stories.js
+++ b/src/components/sample/Sample.stories.js
@@ -10,7 +10,7 @@ import { LINK_TARGETS } from '../link/defs';
 const createSelectOptions = (defs) => [null, ...createOptionsArray(defs)];
 
 export default {
-  title: 'Components/Sample Practise',
+  title: 'Components/Practise/Sample',
   component: 'kd-sample',
   parameters: {
     design: {

--- a/src/components/sample/Sample.stories.js
+++ b/src/components/sample/Sample.stories.js
@@ -31,7 +31,7 @@ export default {
 
 const args = {
   message: 'Hello, Storybook!',
-  submessage: '',
+  submessage: 'Hello, Subtitle!',
   option: '_self',
   'on-click': fn(),
 };
@@ -62,7 +62,7 @@ export const SampleWithSubtitle = {
     html`
       <kd-sample
         message=${args.message}
-        submessage="Hello, Subtitle!"
+        submessage=${args.submessage}
       ></kd-sample>
     `,
 };

--- a/src/components/sample/Sample.stories.js
+++ b/src/components/sample/Sample.stories.js
@@ -1,0 +1,76 @@
+import { html } from 'lit';
+import './index';
+//import { fn } from '@storybook/test';
+
+import { userEvent, expect, waitFor, fn } from '@storybook/test';
+import { within } from 'shadow-dom-testing-library';
+
+import { createOptionsArray } from '../../common/helpers/storybook';
+import { LINK_TARGETS } from '../link/defs';
+const createSelectOptions = (defs) => [null, ...createOptionsArray(defs)];
+
+export default {
+  title: 'Components/Sample Practise',
+  component: 'kd-sample',
+  parameters: {
+    design: {
+      type: 'figma',
+      url: '',
+    },
+  },
+  argTypes: {
+    option: {
+      options: createSelectOptions(LINK_TARGETS),
+      control: { type: 'select', labels: { null: LINK_TARGETS.SELF } },
+      table: {
+        defaultValue: { summary: LINK_TARGETS.SELF },
+      },
+    },
+  },
+};
+
+const args = {
+  message: 'Hello, Storybook!',
+  submessage: '',
+  option: '_self',
+  'on-click': fn(),
+};
+
+export const Sample = {
+  args,
+  render: (args) =>
+    html`
+      <kd-sample
+        message=${args.message}
+        submessage="Hello, Subtitle!"
+        option=${args.option}
+        @on-click=${args['on-click']}
+      ></kd-sample>
+    `,
+  play: async ({ canvasElement }) => {
+    // example interaction test
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByShadowRole('link'));
+    await waitFor(() => expect(args['on-click']).toHaveBeenCalled());
+    canvas.getByShadowRole('link').blur();
+  },
+};
+
+export const SampleWithSubtitle = {
+  args,
+  render: (args) =>
+    html`
+      <kd-sample
+        message=${args.message}
+        submessage="Hello, Subtitle!"
+      ></kd-sample>
+    `,
+};
+
+export const SampleWithOption = {
+  args,
+  render: (args) =>
+    html`
+      <kd-sample message=${args.message} option=${args.option}></kd-sample>
+    `,
+};

--- a/src/components/sample/index.ts
+++ b/src/components/sample/index.ts
@@ -1,0 +1,1 @@
+export { Sample } from './sample';

--- a/src/components/sample/sample.scss
+++ b/src/components/sample/sample.scss
@@ -1,0 +1,11 @@
+// @use '~@kyndryl-design-system/shidoka-foundation/scss/mixins/typography.scss';
+
+:host {
+  /* web components are display: inline; by default */
+  display: block;
+}
+
+.component {
+  font-size: 2rem;
+  font-weight: bolder;
+}

--- a/src/components/sample/sample.ts
+++ b/src/components/sample/sample.ts
@@ -3,14 +3,21 @@ import { customElement, property } from 'lit/decorators.js';
 import Styles from './sample.scss';
 import { LINK_TARGETS } from '../link/defs';
 
+/**
+ * Sample component
+ * @fires on-click - Captures the click event and emits the original event details.
+ */
 @customElement('kd-sample')
 export class Sample extends LitElement {
+  /** message. */
   @property({ type: String })
   message = 'Hi there!';
 
+  /** submessage. */
   @property({ type: String })
   submessage = 'Hi there!';
 
+  /** Possible options include "_self" (default), "_blank", "_parent", "_top" */
   @property({ type: String })
   option: LINK_TARGETS = LINK_TARGETS.SELF;
 

--- a/src/components/sample/sample.ts
+++ b/src/components/sample/sample.ts
@@ -1,0 +1,46 @@
+import { LitElement, html } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+import Styles from './sample.scss';
+import { LINK_TARGETS } from '../link/defs';
+
+@customElement('kd-sample')
+export class Sample extends LitElement {
+  @property({ type: String })
+  message = 'Hi there!';
+
+  @property({ type: String })
+  submessage = 'Hi there!';
+
+  @property({ type: String })
+  option: LINK_TARGETS = LINK_TARGETS.SELF;
+
+  static override styles = Styles;
+
+  override render() {
+    return html`
+      <div
+        class="component"
+        role="link"
+        @click=${(e: Event) => this.handleClick(e)}
+      >
+        ${this.message}
+      </div>
+      <div>${this.submessage}</div>
+      <div>${this.option}</div>
+    `;
+  }
+
+  private handleClick(e: Event) {
+    const event = new CustomEvent('on-click', {
+      detail: { origEvent: e },
+    });
+    console.log('handleClick--', event);
+    this.dispatchEvent(event);
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'kd-sample': Sample;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,6 @@ export { Link } from './components/link';
 export { Accordion, AccordionItem } from './components/accordion';
 export { Card } from './components/card';
 export { SplitButton, SplitButtonOption } from './components/splitButton';
+export { Sample } from './components/sample';
+export { LitLifecycle } from './components/lifecycle';
+export { ExpandableTile } from './components/expandableTile';


### PR DESCRIPTION
Experimenting Lit and storybook
(Expandable-Tile): Added expandable tile, lit lifecycle and sample component

## Summary

Exploring Lit component ans storybook

## ADO Story or GitHub Issue Link

Link here (if applicable).

## Notes

- Detailed change notes
- can go here

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.

## Testing Instructions

Provide guidance to reviewers/testers here.

## Screenshots

(if any)
