### PR TITLE
fix(button): Added missing colour token for tertiary button

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -397,6 +397,7 @@ span {
   &:focus {
     background-color: var(--kd-color-background-button-tertiary-state-focused);
     outline-color: var(--kd-color-border-button-tertiary-state-focused);
+    color: var(--kd-color-text-button-light-primary);
   }
 
   &:disabled {


### PR DESCRIPTION
## Summary

Added missing colour token for tertiary button focus state.

## ADO Story or GitHub Issue Link

[BUG 2047586](https://dev.azure.com/Kyndryl/Shidoka%20-%20Bridge%20Design%20System/_workitems/edit/2047586)

## Checklist

- [ ] Used Conventional Commit messages as outlined in the contributing guide.
  - [ ] Noted breaking changes (if any).
- [ ] Documented/updated all props, events, slots, parts, etc with JSDoc.
  - [ ] Ran the `analyze` command to update Storybook docs.
- [ ] Added/updated Stories with controls to cover all variants.
- [ ] Ran `test` locally to address any failures.
- [ ] Added/updated the Figma link for the Story's Design tab.

## Screenshots
<img width="1726" alt="Screenshot 2024-12-19 at 11 35 07 AM" src="https://github.com/user-attachments/assets/1d640cda-22fe-45ec-9039-f7e6ced2eec7" />
<img width="1728" alt="Screenshot 2024-12-19 at 11 35 17 AM" src="https://github.com/user-attachments/assets/110a8825-ef73-4f43-a254-37f43a013001" />

