### PR TITLE
feat(grid): add compact variant

### DIFF
--- a/src/scss/mixins/grid.scss
+++ b/src/scss/mixins/grid.scss
@@ -4,7 +4,8 @@
   $align-left: false,
   $no-max: false,
   $no-gap: false,
-  $full-bleed: false
+  $full-bleed: false,
+  $compact: false
 ) {
   display: grid;
   grid-template-columns: repeat(4, 1fr); // 4 cols at sm
@@ -12,6 +13,10 @@
   margin: 0 auto;
   max-width: var(--kd-grid-max-width);
   position: relative;
+
+  @if $compact {
+    gap: var(--kd-grid-gap-compact);
+  }
 
   @if $no-gap {
     gap: 0;

--- a/src/scss/utility/grid.scss
+++ b/src/scss/utility/grid.scss
@@ -4,6 +4,10 @@
 .kd-grid {
   @include grid.grid;
 
+  &--compact {
+    gap: var(--kd-grid-gap-compact);
+  }
+
   &--no-gap {
     gap: 0;
   }

--- a/src/scss/variables/grid.scss
+++ b/src/scss/variables/grid.scss
@@ -2,6 +2,7 @@
 
 :root {
   --kd-grid-gap: 16px;
+  --kd-grid-gap-compact: 16px;
   --kd-grid-max-width: 100%;
 
   @media (min-width: breakpoints.$bp-md) {

--- a/src/stories/Grid.mdx
+++ b/src/stories/Grid.mdx
@@ -37,7 +37,8 @@ import * as GridStories from './Grid.stories.js';
     $align-left: false,
     $no-max: false,
     $no-gap: false,
-    $full-bleed: false
+    $full-bleed: false,
+    $compact: false
   );
 }
 
@@ -101,6 +102,7 @@ kd-grid__col--${breakpoint}-${num_cols}
 | Left align grid container       | kd-grid--align-left |
 | Remove grid container max-width | kd-grid--no-max     |
 | Remove column gap               | kd-grid--no-gap     |
+| Compact column gap              | kd-grid--compact    |
 | Full bleed/override page gutter | kd-grid--full-bleed |
 
 ## Page Gutter

--- a/src/stories/Grid.stories.js
+++ b/src/stories/Grid.stories.js
@@ -25,6 +25,13 @@ export default {
         defaultValue: { summary: false },
       },
     },
+    compact: {
+      control: { type: 'boolean' },
+      description: 'Compact column gap.',
+      table: {
+        defaultValue: { summary: false },
+      },
+    },
     fullBleed: {
       control: { type: 'boolean' },
       description: 'Full bleed/override page gutter.',
@@ -90,6 +97,7 @@ const args = {
   noMax: false,
   noGap: false,
   fullBleed: false,
+  compact: false,
   withLocalNav: false,
 };
 
@@ -100,6 +108,7 @@ export const Grid = {
       'kd-grid': true,
       'kd-grid--no-max': args.noMax,
       'kd-grid--no-gap': args.noGap,
+      'kd-grid--compact': args.compact,
       'kd-grid--align-left': args.alignLeft,
       'kd-grid--full-bleed': args.fullBleed,
     };


### PR DESCRIPTION
## Summary

Add `compact` variant for 16px grid gutters, to keep consistency with our gridstack implementation.